### PR TITLE
Changes method for checking for 'all' statistics

### DIFF
--- a/R/export_summ.R
+++ b/R/export_summ.R
@@ -250,7 +250,7 @@ export_summs <- function(...,
     # Keep just the unique entries
     statistics <- stats[!duplicated(stats)]
 
-  } else if (statistics == "all") {
+  } else if (identical(statistics,"all")) {
 
     statistics <- NULL
 


### PR DESCRIPTION
Currently the following throws a warning:

```r
data(mtcars)
m <- lm(hp~mpg, data = mtcars)
export_summs(m, statistics = c(N = 'nobs', R2 = 'r.squared'))
```

which produces 

```
Warning message:
In if (statistics == "all") { :
  the condition has length > 1 and only the first element will be used`
```

This PR simply changes `statistics == "all"` to `identical(statistics, 'all')`, which still checks whether `statistics` is, indeed, equal to 'all', but in a way that accepts a `statistics` vector with length longer than 1.