### PR TITLE
Modernize pkgdown config + check action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -18,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -29,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -41,26 +43,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
-
-      - name: Set CRAN mirror
-        run: echo "options(repos = c(CRAN='https://cloud.r-project.org/'))" > ~/.Rprofile
-
-      - name: Install lme4 from source to fix Matrix errors
-        run: | 
-          install.packages('lme4', type = 'source')
-        shell: Rscript {0}
+          extra-packages: any::rcmdcheck
+          needs: check
 
       - uses: r-lib/actions/check-r-package@v2
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -81,16 +81,23 @@ reference:
 
 
 navbar:
-  left:
-    - icon: fa-home
+  structure:
+    left: [home, news, reference, articles]
+  components:
+    home:
+      icon: fa-home
       href: index.html
-    - icon: fa-newspaper-o
+      aria-label: "Home"
+    news:
+      icon: fa-newspaper-o
       text: "News"
       href: news/index.html
-    - icon: fa-file-code-o
-      text: "Documentation"
+    reference:
+      icon: fa-file-code-o
       href: reference/index.html
-    - icon: fa-book
+      text: "Documentation"
+    articles:
+      icon: fa-book
       text: "Vignettes"
       menu:
       -  text: Tools for summarizing and visualizing regression models
@@ -99,8 +106,3 @@ navbar:
          href: articles/effect_plot.html
       -  text: Calculate correlations and correlation tables with complex survey data
          href: articles/svycor.html
-  right:
-    - icon: fa-github fa-lg
-      text: "Github"
-      href: https://github.com/jacob-long/jtools
-


### PR DESCRIPTION
Similar intent as https://github.com/jacob-long/interactions/pull/78. This brings the search bar back (to be compatible with pkgdown 2.1.0)

It is great that you made the commit to include cli instead of crayon 39866e343098cec2056dbd343109333b31f71590