### PR TITLE
migrate functions from lme4 to reformulas; various test cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     magrittr,
     pander,
     pkgconfig,
+    reformulas,
     rlang,
     sandwich,
     tibble

--- a/R/colors.R
+++ b/R/colors.R
@@ -48,7 +48,7 @@
 #' @references
 #'
 #' Paul Tol's site is what is used to derive 4 of the 6 `jtools`-specific
-#' qualitative palettes: \url{https://personal.sron.nl/~pault/}
+#' qualitative palettes: \url{https://sronpersonalpages.nl/~pault/}
 #'
 #' Okabe and Ito's palette inspired "CUD Bright", though "CUD Bright" is not
 #' exactly the same. "CUD" is the same.

--- a/R/gscale.R
+++ b/R/gscale.R
@@ -90,7 +90,7 @@
 #'
 #' Gelman, A. (2008). Scaling regression inputs by dividing by two standard
 #' deviations. \emph{Statistics in Medicine}, \emph{27}, 2865–2873.
-#' \url{http://www.stat.columbia.edu/~gelman/research/published/standardizing7.pdf}
+#' \url{https://sites.stat.columbia.edu/gelman/research/published/standardizing7.pdf}
 #'
 #' Grotenhuis, M. te, Pelzer, B., Eisinga, R., Nieuwenhuis, R.,
 #'  Schmidt-Catran, A., & Konig, R. (2017). When size matters: Advantages of

--- a/R/lme4_utils.R
+++ b/R/lme4_utils.R
@@ -196,7 +196,7 @@ noReForm <- function(re.form) {
 
 reOnly <- function(f, response = FALSE) {
   response <- if (response && length(f) == 3) { f[[2]] } else { NULL }
-  reformulate(paste0("(", vapply(lme4::findbars(f), safeDeparse,
+  reformulate(paste0("(", vapply(reformulas::findbars(f), safeDeparse,
                                  ""), ")"), response = response)
 }
 
@@ -238,7 +238,7 @@ mkNewReTrms <- function(object, newdata, re.form = NULL, na.action = na.pass,
         0) {
       newdata <- newdata[-fit.na.action, ]
     }
-    ReTrms <- lme4::mkReTrms(lme4::findbars(re.form[[2]]), rfd)
+    ReTrms <- reformulas::mkReTrms(reformulas::findbars(re.form[[2]]), rfd)
     ReTrms <- within(ReTrms, Lambdat@x <- unname(lme4::getME(object,
                                                        "theta")[Lind]))
     if (!allow.new.levels && any(vapply(ReTrms$flist, anyNA,

--- a/R/mer_utils.r
+++ b/R/mer_utils.r
@@ -284,7 +284,7 @@ get.random.formula <- function(model, rhs) {
   random.formula <- if (any(class(model) %in% c("lmerMod", "lmerModLmerTest",
                                                 "glmerMod", "glmmTMB"))) {
 
-        paste("(", lme4::findbars(formula(model)), ")", collapse = " + ")
+        paste("(", reformulas::findbars(formula(model)), ")", collapse = " + ")
 
   }
 

--- a/man/gscale.Rd
+++ b/man/gscale.Rd
@@ -150,7 +150,7 @@ if (requireNamespace("survey")) {
 \references{
 Gelman, A. (2008). Scaling regression inputs by dividing by two standard
 deviations. \emph{Statistics in Medicine}, \emph{27}, 2865–2873.
-\url{http://www.stat.columbia.edu/~gelman/research/published/standardizing7.pdf}
+\url{https://sites.stat.columbia.edu/gelman/research/published/standardizing7.pdf}
 
 Grotenhuis, M. te, Pelzer, B., Eisinga, R., Nieuwenhuis, R.,
 Schmidt-Catran, A., & Konig, R. (2017). When size matters: Advantages of

--- a/man/jtools_colors.Rd
+++ b/man/jtools_colors.Rd
@@ -51,7 +51,7 @@ see all of those options).
 }
 \references{
 Paul Tol's site is what is used to derive 4 of the 6 \code{jtools}-specific
-qualitative palettes: \url{https://personal.sron.nl/~pault/}
+qualitative palettes: \url{https://sronpersonalpages.nl/~pault/}
 
 Okabe and Ito's palette inspired "CUD Bright", though "CUD Bright" is not
 exactly the same. "CUD" is the same.

--- a/vignettes/summ.Rmd
+++ b/vignettes/summ.Rmd
@@ -155,7 +155,7 @@ you would get if you did `scale(log(us_gross))` rather than
 
 You can also choose a different number of standard deviations to divide by for
 standardization. 
-[Andrew Gelman](http://www.stat.columbia.edu/~gelman/research/published/standardizing7.pdf) 
+[Andrew Gelman](https://sites.stat.columbia.edu/gelman/research/published/standardizing7.pdf)
 has been a proponent of dividing by 2 standard
 deviations; if you want to do things that way, give the argument `n.sd = 2`. 
 


### PR DESCRIPTION
This package wasn't failing itself to due to the lme4 to reformulas migration, but was indirectly making `panelr` fail its tests ...
